### PR TITLE
Add support for afp:// (Apple Filing Protocol)

### DIFF
--- a/src/bookmarkeditdialog.c
+++ b/src/bookmarkeditdialog.c
@@ -133,6 +133,7 @@ enum {
 	SCHEME_SMB,
 	SCHEME_DAV,
 	SCHEME_DAVS,
+	SCHEME_AFP,
 	SCHEME_OBEX,
 	SCHEME_CUSTOM
 };
@@ -143,6 +144,7 @@ static struct MethodInfo methods[] = {
 	{ "smb",  0,	SHOW_SHARE | SHOW_USER | SHOW_DOMAIN | SHOW_FOLDER },
 	{ "dav",  80,	SHOW_PATH | SHOW_PORT | SHOW_USER | SHOW_FOLDER },
 	{ "davs", 443,	SHOW_PATH | SHOW_PORT | SHOW_USER | SHOW_FOLDER },
+	{ "afp",  548,	SHOW_PORT | SHOW_USER | SHOW_FOLDER },
 	{ "obex", 0,	SHOW_DEVICE },
 	{ NULL,   0,	0 }
 };

--- a/src/bookmarkeditdialog.c
+++ b/src/bookmarkeditdialog.c
@@ -245,7 +245,7 @@ gint gigolo_bookmark_edit_dialog_run(GigoloBookmarkEditDialog *dialog)
 					gtk_widget_grab_focus(priv->host_entry);
 				}
 			}
-			if (! error && gtk_widget_get_parent(priv->share_combo) != NULL)
+			if (! error && gtk_widget_get_parent(priv->share_combo) != NULL && gtk_widget_get_visible(priv->share_box))
 			{
 				tmp = gtk_entry_get_text(GTK_ENTRY(priv->share_entry));
 				if (! *tmp)
@@ -256,7 +256,7 @@ gint gigolo_bookmark_edit_dialog_run(GigoloBookmarkEditDialog *dialog)
 					gtk_widget_grab_focus(priv->share_combo);
 				}
 			}
-			if (! error && gtk_widget_get_parent(priv->uri_entry) != NULL)
+			if (! error && gtk_widget_get_parent(priv->uri_entry) != NULL && gtk_widget_get_visible(priv->uri_entry))
 			{
 				tmp = gtk_entry_get_text(GTK_ENTRY(priv->uri_entry));
 				if (! *tmp || ! check_custom_uri(tmp))

--- a/src/common.c
+++ b/src/common.c
@@ -89,6 +89,8 @@ const gchar *gigolo_describe_scheme(const gchar *scheme)
 		return _("WebDAV");
 	else if (gigolo_str_equal(scheme, "davs"))
 		return _("WebDAV (secure)");
+	else if (gigolo_str_equal(scheme, "afp"))
+		return _("Apple Filing Protocol");
 	else if (gigolo_str_equal(scheme, "network"))
 		return _("Network");
 	else if (gigolo_str_equal(scheme, "archive"))
@@ -112,6 +114,8 @@ guint gigolo_get_default_port(const gchar *scheme)
 		return 80;
 	else if (gigolo_str_equal(scheme, "davs"))
 		return 443;
+	else if (gigolo_str_equal(scheme, "afp"))
+		return 548;
 
 	return 0;
 }


### PR DESCRIPTION
Add support for afp:// (Apple Filing Protocol) connections.

Tested on Ubuntu 18.04 and Synology NAS DS218j

![screenshot from 2018-12-21 20-55-01](https://user-images.githubusercontent.com/545677/50339273-c3b71400-0562-11e9-9645-4ef7065d775c.png)

![screenshot from 2018-12-21 20-54-46](https://user-images.githubusercontent.com/545677/50339274-c3b71400-0562-11e9-970b-86cfa64583f0.png)
