### PR TITLE
Disable deprecated Status Icon for GTK >= 3.14

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -1094,7 +1094,8 @@ static void gigolo_window_show_systray_icon(GigoloWindow *window, gboolean show)
 	GigoloWindowPrivate *priv = gigolo_window_get_instance_private(window);
 
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS /* Gtk 3.14 */
-	gtk_status_icon_set_visible(priv->systray_icon, show);
+	if (priv->systray_icon)
+		gtk_status_icon_set_visible(priv->systray_icon, show);
 	G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
@@ -1224,6 +1225,7 @@ static void gigolo_window_settings_notify_cb(GigoloSettings *settings, GParamSpe
 {
 	const gchar *name;
 	GValue *value;
+	GigoloWindowPrivate *priv;
 
 	name = g_intern_string(pspec->name);
 	value = g_new0(GValue, 1);
@@ -1238,7 +1240,8 @@ static void gigolo_window_settings_notify_cb(GigoloSettings *settings, GParamSpe
 	}
 	else if (name == g_intern_string("show-in-systray"))
 	{
-		gboolean state = g_value_get_boolean(value);
+		priv = gigolo_window_get_instance_private(window);
+		gboolean state = g_value_get_boolean(value) && priv->systray_icon;
 		gigolo_window_show_systray_icon(window, state);
 		toggle_set_active(window, "ShowInSystray", state);
 	}
@@ -1661,12 +1664,19 @@ static void gigolo_window_init(GigoloWindow *window)
 
 	/* Status icon */
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS /* Gtk 3.14 */
-	priv->systray_icon = gtk_status_icon_new_from_icon_name(gigolo_get_application_icon_name());
-	gtk_status_icon_set_tooltip_text(priv->systray_icon, _("Gigolo"));
+	if (gtk_get_major_version()<3 || gtk_get_major_version()==3 && gtk_get_minor_version()<14)
+	{
+		priv->systray_icon = gtk_status_icon_new_from_icon_name(gigolo_get_application_icon_name());
+		gtk_status_icon_set_tooltip_text(priv->systray_icon, _("Gigolo"));
+		g_signal_connect(priv->systray_icon, "activate", G_CALLBACK(systray_icon_activate_cb), window);
+		g_signal_connect(priv->systray_icon, "popup-menu", G_CALLBACK(systray_icon_popup_menu_cb), window);
+		g_signal_connect(priv->systray_icon, "notify", G_CALLBACK(gigolo_window_systray_notify_cb), window);
+	}
+	else
+	{
+		priv->systray_icon = NULL;
+	}
 	G_GNUC_END_IGNORE_DEPRECATIONS
-	g_signal_connect(priv->systray_icon, "activate", G_CALLBACK(systray_icon_activate_cb), window);
-	g_signal_connect(priv->systray_icon, "popup-menu", G_CALLBACK(systray_icon_popup_menu_cb), window);
-	g_signal_connect(priv->systray_icon, "notify", G_CALLBACK(gigolo_window_systray_notify_cb), window);
 }
 
 

--- a/src/window.c
+++ b/src/window.c
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include <string.h>
+#include <memory.h>
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
@@ -1628,6 +1629,8 @@ static void update_side_panel(GigoloWindow *window)
 
 static void gigolo_window_init(GigoloWindow *window)
 {
+	const char *XDG_CURRENT_DESKTOP = getenv("XDG_CURRENT_DESKTOP");
+
 	GigoloWindowPrivate *priv = gigolo_window_get_instance_private(window);
 
 	priv->autoconnect_timeout_id = (guint) -1;
@@ -1663,20 +1666,21 @@ static void gigolo_window_init(GigoloWindow *window)
 	gtk_widget_show_all(priv->swin_iconview);
 
 	/* Status icon */
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS /* Gtk 3.14 */
-	if (gtk_get_major_version()<3 || gtk_get_major_version()==3 && gtk_get_minor_version()<14)
+	if (!XDG_CURRENT_DESKTOP || strcmp(XDG_CURRENT_DESKTOP, "ubuntu:GNOME"))  /* Not Ubuntu 18.04 */
 	{
+		/* Deprecated in Gtk 3.14, not supported in Gnome3 on Ubuntu 18.04 */
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 		priv->systray_icon = gtk_status_icon_new_from_icon_name(gigolo_get_application_icon_name());
 		gtk_status_icon_set_tooltip_text(priv->systray_icon, _("Gigolo"));
 		g_signal_connect(priv->systray_icon, "activate", G_CALLBACK(systray_icon_activate_cb), window);
 		g_signal_connect(priv->systray_icon, "popup-menu", G_CALLBACK(systray_icon_popup_menu_cb), window);
 		g_signal_connect(priv->systray_icon, "notify", G_CALLBACK(gigolo_window_systray_notify_cb), window);
+		G_GNUC_END_IGNORE_DEPRECATIONS
 	}
 	else
 	{
 		priv->systray_icon = NULL;
 	}
-	G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
 


### PR DESCRIPTION
On Ubuntu 18.04 the use of Systray Icon results in warning messages and a window that can't be enabled.

So, disable this mode at runtime depending on the version of GTK.

